### PR TITLE
Add encounter repository and tests for local persistence

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ from .models import (
     ServerState,
     to_dict,
 )
-from .persistence import save_encounter, load_encounter
+from .persistence import save_encounter, load_encounter, EncounterRepository
 from .network import (
     discover_servers,
     DiscoveryService,
@@ -54,6 +54,7 @@ __all__ = [
     "to_dict",
     "save_encounter",
     "load_encounter",
+    "EncounterRepository",
     "discover_servers",
     "DiscoveryService",
     "ConnectionManager",

--- a/src/persistence.py
+++ b/src/persistence.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from .models import Encounter, to_dict
 
@@ -18,3 +18,48 @@ def load_encounter(path: Union[str, Path]) -> Encounter:
     content = Path(path).read_text()
     data = json.loads(content)
     return Encounter.from_dict(data)
+
+
+class EncounterRepository:
+    """Manage a collection of encounters stored as JSON files.
+
+    Each encounter is stored in its own file inside ``base_path`` using
+    the encounter's ``id`` as filename. The repository offers helpers to
+    save, load, list and delete encounters without exposing file-system
+    details to callers.
+    """
+
+    def __init__(self, base_path: Union[str, Path]) -> None:
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def save(self, encounter: Encounter) -> Path:
+        """Persist ``encounter`` under ``base_path``.
+
+        Returns the path of the written file.
+        """
+
+        file_path = self.base_path / f"{encounter.id}.json"
+        save_encounter(encounter, file_path)
+        return file_path
+
+    def load(self, encounter_id: str) -> Encounter:
+        """Load an encounter by ``encounter_id`` from ``base_path``."""
+
+        file_path = self.base_path / f"{encounter_id}.json"
+        return load_encounter(file_path)
+
+    def list_ids(self) -> List[str]:
+        """Return the list of available encounter identifiers."""
+
+        return [p.stem for p in self.base_path.glob("*.json")]
+
+    def delete(self, encounter_id: str) -> None:
+        """Remove the stored encounter if it exists."""
+
+        file_path = self.base_path / f"{encounter_id}.json"
+        if file_path.exists():
+            file_path.unlink()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+# Ensure src package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.models import Encounter, Entity
+from src.persistence import EncounterRepository, load_encounter, save_encounter
+
+
+def build_encounter(enc_id: str) -> Encounter:
+    return Encounter(
+        id=enc_id,
+        name="Test",
+        participants=[
+            Entity(
+                id="e1",
+                name="Goblin",
+                type="npc",
+                owner_id=None,
+                hp=7,
+                max_hp=7,
+                conditions=[],
+                fatigue=0,
+                initiative=None,
+                notes="",
+            )
+        ],
+        initiative_order=[],
+        current_turn_index=0,
+        is_active=False,
+    )
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    enc = build_encounter("enc1")
+    file_path = tmp_path / "encounter.json"
+    save_encounter(enc, file_path)
+    loaded = load_encounter(file_path)
+    assert loaded == enc
+
+
+def test_repository_operations(tmp_path: Path) -> None:
+    repo = EncounterRepository(tmp_path)
+    enc1 = build_encounter("first")
+    enc2 = build_encounter("second")
+
+    repo.save(enc1)
+    repo.save(enc2)
+
+    assert set(repo.list_ids()) == {"first", "second"}
+
+    loaded = repo.load("second")
+    assert loaded == enc2
+
+    repo.delete("first")
+    assert repo.list_ids() == ["second"]


### PR DESCRIPTION
## Summary
- Extend persistence layer with an EncounterRepository that can save, load, list, and delete encounters from disk
- Expose EncounterRepository through the package initializer
- Cover encounter persistence roundtrip and repository operations with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8982f3508332a5e7bf24c6d8020d